### PR TITLE
Add support for versioned txs (legacy, v0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,11 +1064,8 @@ name = "drift-sdk"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
-<<<<<<< HEAD
- "bytemuck",
-=======
  "base64 0.13.1",
->>>>>>> cargo-add-sdk
+ "bytemuck",
  "drift",
  "env_logger 0.10.1",
  "fnv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,6 +1064,7 @@ name = "drift-sdk"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
+ "bytemuck",
  "drift",
  "fnv",
  "futures-util",

--- a/sdk-rs/Cargo.toml
+++ b/sdk-rs/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 anchor-lang = "0.27.0"
+bytemuck = "1.13.0"
 drift-program = { package = "drift", path = "../programs/drift" }
 fnv = "1.0.7"
 futures-util = "0.3.29"

--- a/sdk-rs/src/constants.rs
+++ b/sdk-rs/src/constants.rs
@@ -8,15 +8,24 @@ pub use drift_program::{
     },
     ID as PROGRAM_ID,
 };
-use solana_sdk::pubkey::Pubkey;
+use solana_sdk::{address_lookup_table_account::AddressLookupTableAccount, pubkey::Pubkey};
+use substreams_solana_macro::b58;
 
 use crate::types::Context;
 
 static STATE_ACCOUNT: OnceLock<Pubkey> = OnceLock::new();
-static SPOT_MARKETS_DEV: OnceLock<&'static [SpotMarket]> = OnceLock::new();
-static SPOT_MARKETS_MAINNET: OnceLock<&'static [SpotMarket]> = OnceLock::new();
-static PERP_MARKETS_DEV: OnceLock<&'static [PerpMarket]> = OnceLock::new();
-static PERP_MARKETS_MAINNET: OnceLock<&'static [PerpMarket]> = OnceLock::new();
+
+/// Return the market lookup table
+pub(crate) const fn market_lookup_table(context: Context) -> Pubkey {
+    match context {
+        Context::DevNet => {
+            Pubkey::new_from_array(b58!("FaMS3U4uBojvGn5FSDEPimddcXsCfwkKsFgMVVnDdxGb"))
+        }
+        Context::MainNet => {
+            Pubkey::new_from_array(b58!("D9cnvzswDikQDf53k4HpQ3KJ9y1Fv3HGGDFYMXnK5T6c"))
+        }
+    }
+}
 
 /// Drift state account
 pub fn state_account() -> &'static Pubkey {
@@ -36,70 +45,71 @@ pub fn derive_spot_market_account(market_index: u16) -> Pubkey {
     account
 }
 
-/// Initialize market metadata
-/// Called once on start up
-pub fn init_markets(context: Context, mut spot: Vec<SpotMarket>, mut perp: Vec<PerpMarket>) {
-    spot.sort_by(|a, b| a.market_index.cmp(&b.market_index));
-    perp.sort_by(|a, b| a.market_index.cmp(&b.market_index));
-    // other code relies on aligned indexes for fast lookups
-    assert!(
-        spot.iter()
-            .enumerate()
-            .all(|(idx, x)| idx == x.market_index as usize),
-        "spot indexes unaligned"
-    );
-    assert!(
-        perp.iter()
-            .enumerate()
-            .all(|(idx, x)| idx == x.market_index as usize),
-        "perp indexes unaligned"
-    );
-    match context {
-        Context::DevNet => {
-            SPOT_MARKETS_DEV.set(Box::leak(spot.into_boxed_slice()));
-            PERP_MARKETS_DEV.set(Box::leak(perp.into_boxed_slice()));
-        }
-        Context::MainNet => {
-            SPOT_MARKETS_MAINNET.set(Box::leak(spot.into_boxed_slice()));
-            PERP_MARKETS_MAINNET.set(Box::leak(perp.into_boxed_slice()));
+/// Static-ish data from onchain drift program
+pub struct ProgramData {
+    spot_markets: &'static [SpotMarket],
+    perp_markets: &'static [PerpMarket],
+    pub lookup_table: AddressLookupTableAccount,
+}
+
+impl ProgramData {
+    /// Return an uninitialized instance of `ProgramData` (useful for bootstraping)
+    pub const fn uninitialized() -> Self {
+        Self {
+            spot_markets: &[],
+            perp_markets: &[],
+            lookup_table: AddressLookupTableAccount {
+                key: Pubkey::new_from_array([0; 32]),
+                addresses: vec![],
+            },
         }
     }
-}
+    /// Initialize `ProgramData`
+    pub fn new(
+        mut spot: Vec<SpotMarket>,
+        mut perp: Vec<PerpMarket>,
+        lookup_table: AddressLookupTableAccount,
+    ) -> Self {
+        spot.sort_by(|a, b| a.market_index.cmp(&b.market_index));
+        perp.sort_by(|a, b| a.market_index.cmp(&b.market_index));
+        // other code relies on aligned indexes for fast lookups
+        assert!(
+            spot.iter()
+                .enumerate()
+                .all(|(idx, x)| idx == x.market_index as usize),
+            "spot indexes unaligned"
+        );
+        assert!(
+            perp.iter()
+                .enumerate()
+                .all(|(idx, x)| idx == x.market_index as usize),
+            "perp indexes unaligned"
+        );
 
-/// Return known spot markets
-pub fn spot_market_configs(context: Context) -> &'static [SpotMarket] {
-    match context {
-        Context::DevNet => SPOT_MARKETS_DEV.get().expect("markets initialized"),
-        Context::MainNet => SPOT_MARKETS_MAINNET.get().expect("markets initialized"),
+        Self {
+            spot_markets: Box::leak(spot.into_boxed_slice()),
+            perp_markets: Box::leak(perp.into_boxed_slice()),
+            lookup_table,
+        }
     }
-}
 
-/// Return the spot market config given a market index
-pub fn spot_market_config_by_index(
-    context: Context,
-    market_index: u16,
-) -> Option<&'static SpotMarket> {
-    match context {
-        Context::DevNet => SPOT_MARKETS_DEV.get()?.get(market_index as usize),
-        Context::MainNet => SPOT_MARKETS_MAINNET.get()?.get(market_index as usize),
+    /// Return known spot markets
+    pub fn spot_market_configs(&self) -> &'static [SpotMarket] {
+        self.spot_markets
     }
-}
 
-/// Return known perp markets
-pub fn perp_market_configs(context: Context) -> &'static [PerpMarket] {
-    match context {
-        Context::DevNet => PERP_MARKETS_DEV.get().expect("markets initialized"),
-        Context::MainNet => PERP_MARKETS_MAINNET.get().expect("markets initialized"),
+    /// Return known perp markets
+    pub fn perp_market_configs(&self) -> &'static [PerpMarket] {
+        self.perp_markets
     }
-}
 
-/// Return the perp market config given a market index
-pub fn perp_market_config_by_index(
-    context: Context,
-    market_index: u16,
-) -> Option<&'static PerpMarket> {
-    match context {
-        Context::DevNet => PERP_MARKETS_DEV.get()?.get(market_index as usize),
-        Context::MainNet => PERP_MARKETS_MAINNET.get()?.get(market_index as usize),
+    /// Return the spot market config given a market index
+    pub fn spot_market_config_by_index(&self, market_index: u16) -> Option<&'static SpotMarket> {
+        self.spot_markets.get(market_index as usize)
+    }
+
+    /// Return the perp market config given a market index
+    pub fn perp_market_config_by_index(&self, market_index: u16) -> Option<&'static PerpMarket> {
+        self.perp_markets.get(market_index as usize)
     }
 }

--- a/sdk-rs/src/constants.rs
+++ b/sdk-rs/src/constants.rs
@@ -45,39 +45,31 @@ pub fn derive_spot_market_account(market_index: u16) -> Pubkey {
     account
 }
 
-pub trait MarketConfig {
-    fn market_type(&self) -> &str;
-    fn symbol(&self) -> String;
+/// Helper methods for market data structs
+pub trait MarketExt {
+    fn market_type(&self) -> &'static str;
+    fn symbol<'a>(&'a self) -> &'a str;
 }
 
-impl MarketConfig for PerpMarket {
-    fn market_type(&self) -> &str {
+impl MarketExt for PerpMarket {
+    fn market_type(&self) -> &'static str {
         "perp"
     }
-
-    fn symbol(&self) -> String {
-        String::from_utf8(self.name.to_vec())
-            .unwrap_or_default()
-            .trim_end_matches('\0')
-            .trim()
-            .to_string()
+    fn symbol<'a>(&'a self) -> &'a str {
+        unsafe { core::str::from_utf8_unchecked(&self.name) }.trim_end()
     }
 }
 
-impl MarketConfig for SpotMarket {
-    fn market_type(&self) -> &str {
+impl MarketExt for SpotMarket {
+    fn market_type(&self) -> &'static str {
         "spot"
     }
-
-    fn symbol(&self) -> String {
-        String::from_utf8(self.name.to_vec())
-            .unwrap_or_default()
-            .trim_end_matches('\0')
-            .trim()
-            .to_string()
+    fn symbol<'a>(&'a self) -> &'a str {
+        unsafe { core::str::from_utf8_unchecked(&self.name) }.trim_end()
     }
 }
-/// Static-ish data from onchain drift program
+
+/// Static-ish metadata from onchain drift program
 pub struct ProgramData {
     spot_markets: &'static [SpotMarket],
     perp_markets: &'static [PerpMarket],

--- a/sdk-rs/src/lib.rs
+++ b/sdk-rs/src/lib.rs
@@ -3,7 +3,7 @@
 use std::{borrow::Cow, sync::Arc, time::Duration};
 
 use anchor_lang::{AccountDeserialize, Discriminator, InstructionData, ToAccountMetas};
-use constants::{derive_spot_market_account, state_account};
+use constants::{derive_spot_market_account, market_lookup_table, state_account, ProgramData};
 use drift_program::{
     controller::position::PositionDirection,
     math::constants::QUOTE_SPOT_MARKET_INDEX,
@@ -22,17 +22,21 @@ use solana_client::{
     rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig},
     rpc_filter::{Memcmp, RpcFilterType},
 };
-pub use solana_sdk::pubkey::Pubkey;
 use solana_sdk::{
     account::{Account, AccountSharedData},
     commitment_config::{CommitmentConfig, CommitmentLevel},
     compute_budget::ComputeBudgetInstruction,
     hash::Hash,
     instruction::{AccountMeta, Instruction},
+    message::{
+        v0::{self},
+        Message, VersionedMessage,
+    },
     signature::{keypair_from_seed, Keypair, Signature},
     signer::Signer,
-    transaction::Transaction,
+    transaction::VersionedTransaction,
 };
+pub use solana_sdk::{address_lookup_table_account::AddressLookupTableAccount, pubkey::Pubkey};
 use tokio::{
     select,
     sync::{
@@ -329,7 +333,7 @@ impl<T: AccountProvider> DriftClient<T> {
     ///
     /// `account` the drift user PDA
     ///
-    /// Returns the deserialzied account data (`User`)
+    /// Returns the deserialized account data (`User`)
     pub async fn get_user_account(&self, account: &Pubkey) -> SdkResult<User> {
         self.backend.get_account(account).await
     }
@@ -337,7 +341,11 @@ impl<T: AccountProvider> DriftClient<T> {
     /// Sign and send a tx to the network
     ///
     /// Returns the signature on success
-    pub async fn sign_and_send(&self, wallet: &Wallet, tx: Transaction) -> SdkResult<Signature> {
+    pub async fn sign_and_send(
+        &self,
+        wallet: &Wallet,
+        tx: VersionedMessage,
+    ) -> SdkResult<Signature> {
         self.backend
             .sign_and_send(wallet, tx)
             .await
@@ -350,24 +358,49 @@ impl<T: AccountProvider> DriftClient<T> {
         self.backend.get_account(&market).await
     }
 
-    /// Initialize a transaction given a (sub)account address and context
+    /// Lookup a market by symbol
+    ///
+    /// This operation is not free so lookups should be reused/cached by the caller
+    ///
+    /// Returns None if symbol does not map to any known market
+    pub fn market_lookup(&self, symbol: &str) -> Option<MarketId> {
+        if symbol.contains('-') {
+            let markets = self.backend.program_data.perp_market_configs();
+            if let Some(market) = markets.iter().find(|m| {
+                unsafe { core::str::from_utf8_unchecked(&m.name) }
+                    .trim_end()
+                    .eq_ignore_ascii_case(symbol)
+            }) {
+                return Some(MarketId::perp(market.market_index));
+            }
+        } else {
+            let markets = self.backend.program_data.spot_market_configs();
+            if let Some(market) = markets.iter().find(|m| {
+                unsafe { core::str::from_utf8_unchecked(&m.name) }
+                    .trim_end()
+                    .eq_ignore_ascii_case(symbol)
+            }) {
+                return Some(MarketId::spot(market.market_index));
+            }
+        }
+
+        None
+    }
+
+    /// Initialize a transaction given a (sub)account address
     ///
     /// ```ignore
     /// let tx = client
-    ///     .init_tx(Context::Devnet, &wallet.sub_account(3))
+    ///     .init_tx(&wallet.sub_account(3))
     ///     .cancel_all_orders()
     ///     .place_orders(...)
     ///     .build();
     /// ```
     /// Returns a `TransactionBuilder` for composing the tx
-    pub async fn init_tx(
-        &self,
-        context: Context,
-        account: &Pubkey,
-    ) -> SdkResult<TransactionBuilder> {
+    pub async fn init_tx(&self, account: &Pubkey) -> SdkResult<TransactionBuilder> {
         let account_data = self.get_user_account(account).await?;
         Ok(TransactionBuilder::new(
-            context,
+            &self.backend.program_data,
             *account,
             Cow::Owned(account_data),
         ))
@@ -377,9 +410,9 @@ impl<T: AccountProvider> DriftClient<T> {
 /// Provides the heavy-lifting and network facing features of the SDK
 /// It is intended to be a singleton
 pub struct DriftClientBackend<T: AccountProvider> {
-    context: Context,
     rpc_client: RpcClient,
     account_provider: T,
+    program_data: ProgramData,
 }
 
 impl<T: AccountProvider> DriftClientBackend<T> {
@@ -390,24 +423,65 @@ impl<T: AccountProvider> DriftClientBackend<T> {
         account_provider: T,
     ) -> SdkResult<DriftClientBackend<T>> {
         let rpc_client = RpcClient::new(endpoint.to_string());
-        let this = Self {
-            context,
+
+        let mut this = Self {
             rpc_client,
             account_provider,
+            program_data: ProgramData::uninitialized(),
         };
-        this.initialize_markets().await?;
+
+        let lookup_table_address = market_lookup_table(context);
+        let (spot, perp, lookup_table_account): (
+            SdkResult<Vec<SpotMarket>>,
+            SdkResult<Vec<PerpMarket>>,
+            SdkResult<Account>,
+        ) = tokio::join!(
+            this.get_program_accounts(),
+            this.get_program_accounts(),
+            this.get_account_raw(&lookup_table_address),
+        );
+        let lookup_table = utils::deserialize_alt(lookup_table_address, &lookup_table_account?)?;
+
+        this.program_data = ProgramData::new(spot?, perp?, lookup_table);
 
         Ok(this)
     }
 
-    /// Load market data from chain
-    async fn initialize_markets(&self) -> SdkResult<()> {
-        let (spot, perp): (SdkResult<Vec<SpotMarket>>, SdkResult<Vec<PerpMarket>>) =
-            tokio::join!(self.get_program_accounts(), self.get_program_accounts());
+    /// Get recent tx priority fees
+    ///
+    /// - `window` # slots to include in the fee calculation
+    async fn get_recent_priority_fees(
+        &self,
+        writable_markets: &[MarketId],
+        window: Option<usize>,
+    ) -> SdkResult<u64> {
+        let addresses: Vec<Pubkey> = writable_markets
+            .iter()
+            .filter_map(|x| match x.kind {
+                MarketType::Spot => self
+                    .program_data
+                    .spot_market_config_by_index(x.index)
+                    .map(|x| x.pubkey),
+                MarketType::Perp => self
+                    .program_data
+                    .perp_market_config_by_index(x.index)
+                    .map(|x| x.pubkey),
+            })
+            .collect();
 
-        constants::init_markets(self.context, spot?, perp?);
+        let response = self
+            .rpc_client
+            .get_recent_prioritization_fees(addresses.as_slice())
+            .await?;
+        let window = window.unwrap_or(5).max(1);
+        let fee = response
+            .iter()
+            .take(window)
+            .map(|x| x.prioritization_fee)
+            .sum::<u64>()
+            / window as u64;
 
-        Ok(())
+        Ok(fee)
     }
 
     /// Get all drift program accounts by Anchor type
@@ -435,7 +509,8 @@ impl<T: AccountProvider> DriftClientBackend<T> {
         accounts
             .iter()
             .map(|(_, account_data)| {
-                U::try_deserialize(&mut account_data.data.as_ref()).map_err(Into::into)
+                U::try_deserialize(&mut account_data.data.as_ref())
+                    .map_err(|err| Box::new(err).into())
             })
             .collect()
     }
@@ -446,16 +521,24 @@ impl<T: AccountProvider> DriftClientBackend<T> {
         U::try_deserialize(&mut account_data.data.as_ref()).map_err(|_err| SdkError::InvalidAccount)
     }
 
+    /// Fetch an `account`
+    async fn get_account_raw(&self, account: &Pubkey) -> SdkResult<Account> {
+        self.account_provider
+            .get_account(*account)
+            .await
+            .map_err(Into::into)
+    }
+
     /// Sign and send a tx to the network
     ///
     /// Returns the signature on success
     pub async fn sign_and_send(
         &self,
         wallet: &Wallet,
-        mut tx: Transaction,
+        tx: VersionedMessage,
     ) -> SdkResult<Signature> {
         let recent_block_hash = self.rpc_client.get_latest_blockhash().await?;
-        wallet.sign_tx(&mut tx, recent_block_hash);
+        let tx = wallet.sign_tx(tx, recent_block_hash)?;
         self.rpc_client
             .send_transaction(&tx)
             .await
@@ -474,44 +557,77 @@ impl<T: AccountProvider> DriftClientBackend<T> {
 /// let client = DriftClient::new("api.example.com").await.unwrap();
 /// let account_data = client.get_account(wallet.default_sub_account()).await.unwrap();
 ///
-/// let tx = TransactionBuilder::new(Context::Devnet, wallet.default_sub_account(), account_data.into())
+/// let tx = TransactionBuilder::new(client.program_data, wallet.default_sub_account(), account_data.into())
 ///     .cancel_all_orders()
 ///     .place_orders(&[
 ///         NewOrder::default().build(),
 ///         NewOrder::default().build(),
 ///     ])
+///     .legacy()
 ///     .build();
 ///
 /// let signature = client.sign_and_send(tx, &wallet).await?;
 /// ```
 ///
 pub struct TransactionBuilder<'a> {
-    /// wallet to use for tx signing and authority
-    context: Context,
+    /// contextual on-chain program data
+    program_data: &'a ProgramData,
     /// sub-account data
     account_data: Cow<'a, User>,
     /// the drift sub-account address
     sub_account: Pubkey,
+    /// the account to pay for the tx
+    payer: Option<Pubkey>,
     /// ordered list of instructions
     ixs: Vec<Instruction>,
+    /// use legacy transaction mode
+    legacy: bool,
+    /// add additional lookup tables (v0 only)
+    lookup_tables: Vec<AddressLookupTableAccount>,
 }
 
 impl<'a> TransactionBuilder<'a> {
     /// Initialize a new `TransactionBuilder`
     ///
-    /// `context` mainnet or devnet
     /// `sub_account` drift sub-account address
     /// `account_data` drift sub-account data
-    pub fn new<'b>(context: Context, sub_account: Pubkey, account_data: Cow<'b, User>) -> Self
+    pub fn new<'b>(
+        program_data: &'b ProgramData,
+        sub_account: Pubkey,
+        account_data: Cow<'b, User>,
+    ) -> Self
     where
         'b: 'a,
     {
         Self {
-            context,
+            program_data,
             account_data,
             sub_account,
+            payer: None,
             ixs: Default::default(),
+            lookup_tables: vec![program_data.lookup_table.clone()],
+            legacy: false,
         }
+    }
+    /// Use legacy tx mode
+    pub fn legacy(mut self) -> Self {
+        self.legacy = true;
+        self
+    }
+    /// Set the tx lookup tables
+    pub fn lookup_tables(mut self, lookup_tables: &[AddressLookupTableAccount]) -> Self {
+        self.lookup_tables = lookup_tables.to_vec();
+        self.lookup_tables
+            .push(self.program_data.lookup_table.clone());
+
+        self
+    }
+    /// Set the tx fee payer
+    ///
+    /// defaults to the account authority
+    pub fn payer(mut self, payer: Pubkey) -> Self {
+        self.payer = Some(payer);
+        self
     }
     /// Set the priority fee of the tx
     ///
@@ -529,7 +645,7 @@ impl<'a> TransactionBuilder<'a> {
             .collect();
 
         let accounts = build_accounts(
-            self.context,
+            self.program_data,
             drift_program::accounts::PlaceOrder {
                 state: *state_account(),
                 authority: self.account_data.authority,
@@ -556,7 +672,7 @@ impl<'a> TransactionBuilder<'a> {
     /// Cancel all orders for account
     pub fn cancel_all_orders(mut self) -> Self {
         let accounts = build_accounts(
-            self.context,
+            self.program_data,
             drift_program::accounts::CancelOrder {
                 state: *state_account(),
                 authority: self.account_data.authority,
@@ -593,7 +709,7 @@ impl<'a> TransactionBuilder<'a> {
     ) -> Self {
         let (idx, kind) = market;
         let accounts = build_accounts(
-            self.context,
+            self.program_data,
             drift_program::accounts::CancelOrder {
                 state: *state_account(),
                 authority: self.account_data.authority,
@@ -621,7 +737,7 @@ impl<'a> TransactionBuilder<'a> {
     /// Cancel orders given ids
     pub fn cancel_orders_by_id(mut self, order_ids: Vec<u32>) -> Self {
         let accounts = build_accounts(
-            self.context,
+            self.program_data,
             drift_program::accounts::CancelOrder {
                 state: *state_account(),
                 authority: self.account_data.authority,
@@ -648,7 +764,7 @@ impl<'a> TransactionBuilder<'a> {
     pub fn modify_orders(mut self, orders: Vec<(u32, ModifyOrderParams)>) -> Self {
         for (order_id, params) in orders {
             let accounts = build_accounts(
-                self.context,
+                self.program_data,
                 drift_program::accounts::PlaceOrder {
                     state: *state_account(),
                     authority: self.account_data.authority,
@@ -673,9 +789,24 @@ impl<'a> TransactionBuilder<'a> {
         self
     }
 
-    /// Build the transaction ready for signing and sending
-    pub fn build(self) -> Transaction {
-        Transaction::new_with_payer(self.ixs.as_ref(), Some(&self.account_data.authority))
+    /// Build the transaction message ready for signing and sending
+    pub fn build(self) -> VersionedMessage {
+        if self.legacy {
+            let message = Message::new(
+                self.ixs.as_ref(),
+                self.payer.as_ref().or(Some(&self.account_data.authority)),
+            );
+            VersionedMessage::Legacy(message)
+        } else {
+            let message = v0::Message::try_compile(
+                self.payer.as_ref().unwrap_or(&self.account_data.authority),
+                self.ixs.as_slice(),
+                self.lookup_tables.as_slice(),
+                Default::default(),
+            )
+            .expect("ok");
+            VersionedMessage::V0(message)
+        }
     }
 }
 
@@ -692,7 +823,7 @@ impl<'a> TransactionBuilder<'a> {
 /// # Panics
 ///  if the user has positions in an unknown market (i.e unsupported by the SDK)
 fn build_accounts(
-    context: Context,
+    program_data: &ProgramData,
     base_accounts: impl ToAccountMetas,
     user: &User,
     markets_readable: &[MarketId],
@@ -714,8 +845,9 @@ fn build_accounts(
 
         let (account, oracle) = match market_type {
             MarketType::Spot => {
-                let SpotMarket { pubkey, oracle, .. } =
-                    constants::spot_market_config_by_index(context, market_index).expect("exists");
+                let SpotMarket { pubkey, oracle, .. } = program_data
+                    .spot_market_config_by_index(market_index)
+                    .expect("exists");
                 (
                     RemainingAccount::Spot {
                         pubkey: *pubkey,
@@ -725,8 +857,9 @@ fn build_accounts(
                 )
             }
             MarketType::Perp => {
-                let PerpMarket { pubkey, amm, .. } =
-                    constants::perp_market_config_by_index(context, market_index).expect("exists");
+                let PerpMarket { pubkey, amm, .. } = program_data
+                    .perp_market_config_by_index(market_index)
+                    .expect("exists");
                 (
                     RemainingAccount::Perp {
                         pubkey: *pubkey,
@@ -834,9 +967,14 @@ impl Wallet {
             Pubkey::find_program_address(&[&b"user_stats"[..], account.as_ref()], program);
         account_drift_pda
     }
-    /// Signs the given `tx`
-    pub fn sign_tx(&self, tx: &mut Transaction, recent_block_hash: Hash) {
-        tx.sign(&[self.signer.as_ref()], recent_block_hash)
+    /// Signs the given tx `message` returning the tx on success
+    pub fn sign_tx(
+        &self,
+        mut message: VersionedMessage,
+        recent_block_hash: Hash,
+    ) -> SdkResult<VersionedTransaction> {
+        message.set_recent_blockhash(recent_block_hash);
+        VersionedTransaction::try_new(message, &[self.signer.as_ref()]).map_err(Into::into)
     }
     /// Return the wallet authority address
     pub fn authority(&self) -> &Pubkey {
@@ -864,8 +1002,7 @@ impl Wallet {
 mod tests {
     use std::str::FromStr;
 
-    use anchor_lang::Discriminator;
-    use drift_program::state::{perp_market::PerpMarket, traits::Size};
+    use drift_program::state::perp_market::PerpMarket;
     use serde_json::json;
     use solana_account_decoder::{UiAccount, UiAccountData};
     use solana_client::{
@@ -886,7 +1023,6 @@ mod tests {
         account_provider_mocks: Mocks,
     ) -> DriftClient<RpcAccountProvider> {
         let backend = DriftClientBackend {
-            context: Context::DevNet,
             rpc_client: RpcClient::new_mock_with_mocks(DEVNET_ENDPOINT.to_string(), rpc_mocks),
             account_provider: RpcAccountProvider {
                 client: RpcClient::new_mock_with_mocks(
@@ -894,6 +1030,7 @@ mod tests {
                     account_provider_mocks,
                 ),
             },
+            program_data: ProgramData::uninitialized(),
         };
 
         DriftClient {

--- a/sdk-rs/src/utils.rs
+++ b/sdk-rs/src/utils.rs
@@ -6,10 +6,7 @@ use solana_sdk::{
     pubkey::Pubkey, signature::Keypair,
 };
 
-use crate::{
-    constants::MarketConfig,
-    types::{SdkError, SdkResult},
-};
+use crate::types::{SdkError, SdkResult};
 
 // kudos @wphan
 /// Try to parse secret `key` string
@@ -86,12 +83,16 @@ pub fn http_to_ws(url: &str) -> Result<String, &'static str> {
     Ok(format!("{}/ws", base_url.trim_end_matches('/')))
 }
 
-pub fn to_ws_json(config: &impl MarketConfig) -> String {
+pub fn dlob_subscribe_ws_json(market: &str) -> String {
     json!({
         "type": "subscribe",
-        "marketType": config.market_type(),
+        "marketType": if market.ends_with("perp") {
+            "perp"
+        } else {
+            "spot"
+        },
         "channel": "orderbook",
-        "market": config.symbol()
+        "market": market,
     })
     .to_string()
 }

--- a/sdk-rs/tests/integration.rs
+++ b/sdk-rs/tests/integration.rs
@@ -1,17 +1,15 @@
-use std::borrow::Cow;
-
-use drift_program::math::constants::{LAMPORTS_PER_SOL_I64, QUOTE_PRECISION_U64};
+use drift_program::math::constants::{
+    BASE_PRECISION_I64, LAMPORTS_PER_SOL_I64, PRICE_PRECISION_U64, QUOTE_PRECISION_U64,
+};
 use drift_sdk::{
-    types::{Context, MarketId, NewOrder},
-    DriftClient, RpcAccountProvider, TransactionBuilder, Wallet,
+    types::{Context, NewOrder},
+    DriftClient, RpcAccountProvider, Wallet,
 };
 
-#[ignore]
 #[tokio::test]
 async fn place_and_cancel_orders() {
-    let context = Context::DevNet;
     let client = DriftClient::new(
-        context,
+        Context::DevNet,
         "https://api.devnet.solana.com",
         RpcAccountProvider::new("https://api.devnet.solana.com"),
     )
@@ -22,34 +20,28 @@ async fn place_and_cancel_orders() {
         "4ZT38mSeFhzzDRCMTMbwDp7VYWDqNfkvDR42Wv4Hu9cKzbZPJoVapQSrjLbs9aMPrpAMmN1cQinztnP2PzKVjzwX",
     );
 
-    let user_data = client
-        .get_user_account(&wallet.default_sub_account())
+    let sol_perp = client.market_lookup("sol-perp").expect("exists");
+    let sol_spot = client.market_lookup("sol").expect("exists");
+
+    let tx = client
+        .init_tx(&wallet.default_sub_account())
         .await
-        .expect("ok");
-
-    let sol_perp = MarketId::lookup(context, "sol-perp").expect("exists");
-    let sol_spot = MarketId::lookup(context, "sol").expect("exists");
-
-    let tx = TransactionBuilder::new(
-        context,
-        wallet.default_sub_account(),
-        Cow::Borrowed(&user_data),
-    )
-    .cancel_all_orders()
-    .place_orders(vec![
-        NewOrder::limit(sol_perp)
-            .amount(-1 * LAMPORTS_PER_SOL_I64)
-            .price(100 * QUOTE_PRECISION_U64)
-            .post_only(true)
-            .build(),
-        NewOrder::limit(sol_spot)
-            .amount(1 * LAMPORTS_PER_SOL_I64)
-            .price(22 * QUOTE_PRECISION_U64)
-            .post_only(true)
-            .build(),
-    ])
-    .cancel_all_orders()
-    .build();
+        .unwrap()
+        .cancel_all_orders()
+        .place_orders(vec![
+            NewOrder::limit(sol_perp)
+                .amount(-1 * BASE_PRECISION_I64)
+                .price(200 * PRICE_PRECISION_U64)
+                .post_only(true)
+                .build(),
+            NewOrder::limit(sol_spot)
+                .amount(1 * LAMPORTS_PER_SOL_I64)
+                .price(44 * PRICE_PRECISION_U64)
+                .post_only(true)
+                .build(),
+        ])
+        .cancel_all_orders()
+        .build();
 
     let result = client.sign_and_send(&wallet, tx).await;
     dbg!(&result);


### PR DESCRIPTION
Adds:
- support for v0 transactions with lookup tables
the solana_sdk here is locked to 1.14 (due to anchor and solana-program versions) so AddressLookup table doesn't really exist, had to copy the deserialization code from 1.17.x

Changes:
- allow setting the `payer` in tx builder
- Refactor static markets data as a field on the backend client struct.

the constants were an anti-pattern since they always have to be pulled from the chain to use the sdk/Client properly
also things like live updating the oracle price/amm need to be sync'd anyway so this is groundwork for that

TODO:
- add some integration tests