### PR TITLE
tidy ups

### DIFF
--- a/sdk-rs/Cargo.toml
+++ b/sdk-rs/Cargo.toml
@@ -5,12 +5,15 @@ edition = "2021"
 
 [features]
 rpc_tests = []
+test_utils = []
 
 [dependencies]
 anchor-lang = "0.27.0"
 bytemuck = "1.13.0"
 base64 = "0.13"
-drift = { git = "https://github.com/drift-labs/protocol-v2.git", tag = "v2.53.0", features = ["mainnet-beta"] }
+drift = { git = "https://github.com/drift-labs/protocol-v2.git", tag = "v2.53.0", features = [
+    "mainnet-beta",
+] }
 env_logger = "0.10.1"
 fnv = "1.0.7"
 futures-util = "0.3.29"

--- a/sdk-rs/src/auction_subscriber.rs
+++ b/sdk-rs/src/auction_subscriber.rs
@@ -76,15 +76,14 @@ mod tests {
     use anchor_client::Cluster;
 
     use super::*;
-
-    // this is my (frank) free helius endpoint
-    const MAINNET_ENDPOINT: &str =
-        "https://mainnet.helius-rpc.com/?api-key=3a1ca16d-e181-4755-9fe7-eac27579b48c";
+    use crate::{
+        utils::envs::mainnet_endpoint, websocket_program_account_subscriber::ProgramAccountUpdate,
+    };
 
     #[cfg(feature = "rpc_tests")]
     #[tokio::test]
     async fn test_auction_subscriber() {
-        let cluster = Cluster::from_str(MAINNET_ENDPOINT).unwrap();
+        let cluster = Cluster::from_str(&mainnet_endpoint()).unwrap();
         let url = cluster.ws_url().to_string();
 
         let config = AuctionSubscriberConfig {

--- a/sdk-rs/src/dlob.rs
+++ b/sdk-rs/src/dlob.rs
@@ -259,13 +259,12 @@ where
 #[cfg(test)]
 mod tests {
     use futures_util::StreamExt;
+    use solana_sdk::signature::Keypair;
 
     use super::*;
-    use crate::{types::Context, DriftClient, MarketExt, RpcAccountProvider};
-
-    // this is my (frank) free helius endpoint
-    const MAINNET_ENDPOINT: &str =
-        "https://mainnet.helius-rpc.com/?api-key=3a1ca16d-e181-4755-9fe7-eac27579b48c";
+    use crate::{
+        types::Context, utils::envs::mainnet_endpoint, DriftClient, MarketExt, RpcAccountProvider,
+    };
 
     #[cfg(feature = "rpc_tests")]
     #[tokio::test]
@@ -318,8 +317,8 @@ mod tests {
     async fn subscribe_ws() {
         let client = DriftClient::new(
             Context::MainNet,
-            MAINNET_ENDPOINT,
-            RpcAccountProvider::new(MAINNET_ENDPOINT),
+            RpcAccountProvider::new(&mainnet_endpoint()),
+            Keypair::new().into(),
         )
         .await
         .unwrap();

--- a/sdk-rs/src/lib.rs
+++ b/sdk-rs/src/lib.rs
@@ -408,7 +408,7 @@ impl<T: AccountProvider> DriftClient<T> {
         Ok(user
             .perp_positions
             .iter()
-            .find(|p| p.market_index == market_index)
+            .find(|p| p.market_index == market_index && !p.is_available())
             .copied())
     }
 
@@ -427,7 +427,7 @@ impl<T: AccountProvider> DriftClient<T> {
         Ok(user
             .spot_positions
             .iter()
-            .find(|p| p.market_index == market_index)
+            .find(|p| p.market_index == market_index && !p.is_available())
             .copied())
     }
 
@@ -451,7 +451,7 @@ impl<T: AccountProvider> DriftClient<T> {
     pub async fn get_user(&self) -> SdkResult<User> {
         let user_pubkey = Wallet::derive_user_account(
             self.wallet().authority(),
-            self.active_sub_account_id.into(),
+            self.active_sub_account_id,
             &constants::PROGRAM_ID,
         );
         self.backend.get_account(&user_pubkey).await

--- a/sdk-rs/src/lib.rs
+++ b/sdk-rs/src/lib.rs
@@ -445,7 +445,7 @@ impl<T: AccountProvider> DriftClient<T> {
         self.backend.get_account(account).await
     }
 
-    /// Get your user account data
+    /// Get the _active_ user account data
     ///
     /// Returns the deserialized account data (`User`)
     pub async fn get_user(&self) -> SdkResult<User> {

--- a/sdk-rs/src/slot_subscriber.rs
+++ b/sdk-rs/src/slot_subscriber.rs
@@ -128,19 +128,15 @@ mod tests {
     use anchor_client::Cluster;
 
     use super::*;
-
-    // this is my (frank) free helius endpoint
-    const MAINNET_ENDPOINT: &str =
-        "https://mainnet.helius-rpc.com/?api-key=3a1ca16d-e181-4755-9fe7-eac27579b48c";
+    use crate::utils::envs::mainnet_endpoint;
 
     #[cfg(feature = "rpc_tests")]
     #[tokio::test]
     async fn test_subscribe() {
-        let cluster = Cluster::from_str(MAINNET_ENDPOINT).unwrap();
+        let cluster = Cluster::from_str(&mainnet_endpoint()).unwrap();
         let url = cluster.ws_url().to_string();
 
         let mut slot_subscriber = SlotSubscriber::new(url);
-
         let _ = slot_subscriber.subscribe().await;
 
         slot_subscriber

--- a/sdk-rs/src/utils.rs
+++ b/sdk-rs/src/utils.rs
@@ -115,6 +115,22 @@ where
     T::try_deserialize(&mut decoded_data_slice).map_err(|err| SdkError::Anchor(Box::new(err)))
 }
 
+#[cfg(any(test, test_utils))]
+pub mod envs {
+    //! test env vars
+    use solana_sdk::signature::Keypair;
+
+    /// solana mainnet endpoint
+    pub fn mainnet_endpoint() -> String {
+        std::env::var("TEST_MAINNET_ENDPOINT").expect("TEST_MAINNET_ENDPOINT set")
+    }
+    /// keypair for integration tests
+    pub fn test_keypair() -> Keypair {
+        let private_key = std::env::var("TEST_PRIVATE_KEY").expect("TEST_PRIVATE_KEY set");
+        Keypair::from_base58_string(private_key.as_str())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use solana_sdk::signer::Signer;

--- a/sdk-rs/src/websocket_program_account_subscriber.rs
+++ b/sdk-rs/src/websocket_program_account_subscriber.rs
@@ -181,11 +181,10 @@ mod tests {
     use drift::state::user::User;
 
     use super::*;
-    use crate::memcmp::{get_non_idle_user_filter, get_user_filter};
-
-    // this is my (frank) free helius endpoint
-    const MAINNET_ENDPOINT: &str =
-        "https://mainnet.helius-rpc.com/?api-key=3a1ca16d-e181-4755-9fe7-eac27579b48c";
+    use crate::{
+        memcmp::{get_non_idle_user_filter, get_user_filter},
+        utils::envs::mainnet_endpoint,
+    };
 
     #[cfg(feature = "rpc_tests")]
     #[tokio::test]
@@ -197,7 +196,7 @@ mod tests {
             commitment,
             encoding: UiAccountEncoding::Base64,
         };
-        let cluster = Cluster::from_str(MAINNET_ENDPOINT).unwrap();
+        let cluster = Cluster::from_str(&mainnet_endpoint()).unwrap();
         let url = cluster.ws_url().to_string();
         let subscription_name = "Test".to_string();
 

--- a/sdk-rs/tests/integration.rs
+++ b/sdk-rs/tests/integration.rs
@@ -1,8 +1,7 @@
-use std::str::FromStr;
-
 use drift::math::constants::{BASE_PRECISION_I64, LAMPORTS_PER_SOL_I64, PRICE_PRECISION_U64};
 use drift_sdk::{
     types::{ClientOpts, Context, MarketId, NewOrder},
+    utils::envs::test_keypair,
     DriftClient, RpcAccountProvider, Wallet,
 };
 use solana_sdk::signature::Keypair;
@@ -36,10 +35,7 @@ async fn place_and_cancel_orders() {
     .await
     .expect("connects");
 
-    let wallet = Wallet::from_seed_bs58(
-        "4ZT38mSeFhzzDRCMTMbwDp7VYWDqNfkvDR42Wv4Hu9cKzbZPJoVapQSrjLbs9aMPrpAMmN1cQinztnP2PzKVjzwX",
-    );
-
+    let wallet: Wallet = test_keypair().into();
     let sol_perp = client.market_lookup("sol-perp").expect("exists");
     let sol_spot = client.market_lookup("sol").expect("exists");
 


### PR DESCRIPTION
- fix for spot/perp position helpers when position is default

Put test vars behind envs
- TEST_MAINNET_ENDPOINT
- TEST_PRIVATE_KEY